### PR TITLE
Add case scenario for null

### DIFF
--- a/force-app/main/default/classes/GroupLeader_Test.cls
+++ b/force-app/main/default/classes/GroupLeader_Test.cls
@@ -115,6 +115,13 @@ private class GroupLeader_Test
     }
 
     @isTest
+    private static void TestSayNothingNull()
+    {
+        GroupLeader leader = new GroupLeader();
+        System.assertEquals('Don\'t be shy, this is a safe place.', leader.yoLeader(null));
+    }
+
+    @isTest
     private static void TestDefault()
     {
         GroupLeader leader=new GroupLeader();

--- a/src/classes/GroupLeader_Test.cls
+++ b/src/classes/GroupLeader_Test.cls
@@ -115,6 +115,13 @@ private class GroupLeader_Test
     }
 
     @isTest
+    private static void TestSayNothingNull()
+    {
+        GroupLeader leader = new GroupLeader();
+        System.assertEquals('Don\'t be shy, this is a safe place.', leader.yoLeader(null));
+    }
+
+    @isTest
     private static void TestDefault()
     {
         GroupLeader leader=new GroupLeader();


### PR DESCRIPTION
It would be a good addition to teach mentees how to deal with nulls. In the real world, you very often have to be prepared for a situation like that when null comes as a value even if you don't expect it.

Adding the proposed case scenario will surely increase the complexity of this challenge and can be addressed in many different ways which in turn promotes a variety of solutions.

I think it's a beneficial addition, but I leave it for your judgment whether it's wanted.